### PR TITLE
Upgrade to nvbit-1.7.2

### DIFF
--- a/GPU-FPX/analyzer/Makefile.patch
+++ b/GPU-FPX/analyzer/Makefile.patch
@@ -1,7 +1,34 @@
---- ./record_reg_vals/Makefile	2022-02-03 09:33:25.000000000 -0700
-+++ ./GPU-FPX/analyzer/Makefile	2023-06-05 16:50:20.221954610 -0600
-@@ -1,4 +1,15 @@
--NVCC=nvcc -ccbin=$(CXX) -D_FORCE_INLINES
+--- ./record_reg_vals/Makefile	2024-12-12 14:29:26.000000000 -0700
++++ ./GPU-FPX/analyzer/Makefile	2024-12-17 12:35:08.959056247 -0700
+@@ -1,34 +1,15 @@
+-# SPDX-FileCopyrightText: Copyright (c) 2017 NVIDIA CORPORATION & AFFILIATES.
+-# All rights reserved.
+-# SPDX-License-Identifier: BSD-3-Clause
+-#
+-# Redistribution and use in source and binary forms, with or without
+-# modification, are permitted provided that the following conditions are met:
+-#
+-# 1. Redistributions of source code must retain the above copyright notice, this
+-# list of conditions and the following disclaimer.
+-#
+-# 2. Redistributions in binary form must reproduce the above copyright notice,
+-# this list of conditions and the following disclaimer in the documentation
+-# and/or other materials provided with the distribution.
+-#
+-# 3. Neither the name of the copyright holder nor the names of its
+-# contributors may be used to endorse or promote products derived from
+-# this software without specific prior written permission.
+-#
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 +mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 +current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 +
@@ -13,14 +40,26 @@
 +SUBDIRS   = $(filter-out ./,$(dir $(SUBMAKEFILES)))
 +.PHONY : $(SUBDIRS)
 +
-+
+ 
+-NVCC=nvcc -ccbin=$(CXX) -D_FORCE_INLINES
+-PTXAS=ptxas
  
  NVCC_VER_REQ=10.1
  NVCC_VER=$(shell $(NVCC) --version | grep release | cut -f2 -d, | cut -f3 -d' ')
-@@ -8,8 +19,9 @@
+@@ -38,18 +19,9 @@
  $(error ERROR: nvcc version >= $(NVCC_VER_REQ) required to compile an nvbit tool! Instrumented applications can still use lower versions of nvcc.)
  endif
  
+-PTXAS_VER_ADD_FLAG=12.3
+-PTXAS_VER=$(shell $(PTXAS) --version | grep release | cut -f2 -d, | cut -f3 -d' ')
+-PTXAS_VER_CHECK=$(shell echo "${PTXAS_VER} >= $(PTXAS_VER_ADD_FLAG)" | bc)
+-
+-ifeq ($(PTXAS_VER_CHECK), 0)
+-MAXRREGCOUNT_FLAG=-maxrregcount=24
+-else
+-MAXRREGCOUNT_FLAG=
+-endif
+-
 -NVBIT_PATH=../../core
 -INCLUDES=-I$(NVBIT_PATH)
 +NVBIT_PATH=../../../core
@@ -29,17 +68,17 @@
  
  LIBS=-L$(NVBIT_PATH) -lnvbit
  NVCC_PATH=-L $(subst bin/nvcc,lib64,$(shell which nvcc | tr -s /))
-@@ -17,23 +29,39 @@
+@@ -57,23 +29,39 @@
  SOURCES=$(wildcard *.cu)
  
  OBJECTS=$(SOURCES:.cu=.o)
--ARCH?=35
+-ARCH?=all
+-
+-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+-current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 +#ARCH?=35
 +#ARCH?=70
  
--mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
--current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
--
 -NVBIT_TOOL=$(current_dir).so
 +# mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 +# current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
@@ -49,16 +88,19 @@
  all: $(NVBIT_TOOL)
  
  $(NVBIT_TOOL): $(OBJECTS) $(NVBIT_PATH)/libnvbit.a
- 	$(NVCC) -arch=sm_$(ARCH) -O3 $(OBJECTS) $(LIBS) $(NVCC_PATH) -lcuda -lcudart_static -shared -o $@
+-	$(NVCC) -arch=$(ARCH) -O3 $(OBJECTS) $(LIBS) $(NVCC_PATH) -lcuda -lcudart_static -shared -o $@
++	$(NVCC) -arch=sm_$(ARCH) -O3 $(OBJECTS) $(LIBS) $(NVCC_PATH) -lcuda -lcudart_static -shared -o $@
  
 -%.o: %.cu common.h
+-	$(NVCC) -dc -c -std=c++11 $(INCLUDES) -Xptxas -cloning=no -Xcompiler -Wall -arch=$(ARCH) -O3 -Xcompiler -fPIC $< -o $@
 +%.o: %.cu
- 	$(NVCC) -dc -c -std=c++11 $(INCLUDES) -Xptxas -cloning=no -Xcompiler -Wall -arch=sm_$(ARCH) -O3 -Xcompiler -fPIC $< -o $@
++	$(NVCC) -dc -c -std=c++11 $(INCLUDES) -Xptxas -cloning=no -Xcompiler -Wall -arch=sm_$(ARCH) -O3 -Xcompiler -fPIC $< -o $@
  
 -inject_funcs.o: inject_funcs.cu common.h
+-	$(NVCC) $(INCLUDES) $(MAXRREGCOUNT_FLAG) -Xptxas -astoolspatch --keep-device-functions -arch=$(ARCH) -Xcompiler -Wall -Xcompiler -fPIC -c $< -o $@
 +inject_funcs.o: inject_funcs.cu 
- 	$(NVCC) $(INCLUDES) -maxrregcount=24 -Xptxas -astoolspatch --keep-device-functions -arch=sm_$(ARCH) -Xcompiler -Wall -Xcompiler -fPIC -c $< -o $@
- 
++	$(NVCC) $(INCLUDES) -maxrregcount=24 -Xptxas -astoolspatch --keep-device-functions -arch=sm_$(ARCH) -Xcompiler -Wall -Xcompiler -fPIC -c $< -o $@
++
 +test: SUBDIRS_TEST
 +
 +SUBDIRS_TEST: $(SUBDIRS)
@@ -68,7 +110,7 @@
 +	for dir in $(SUBDIRS); do \
 +		(cd $$dir && make && python3 ../../../verify_except.py ./main && cd -;) \
 +	done
-+
+ 
  clean:
  	rm -f *.so *.o
 +

--- a/GPU-FPX/analyzer/analyzer.patch
+++ b/GPU-FPX/analyzer/analyzer.patch
@@ -1,6 +1,55 @@
---- ./record_reg_vals/record_reg_vals.cu	2022-02-03 09:33:25.000000000 -0700
-+++ ./GPU-FPX/analyzer/analyzer.cu	2023-06-05 16:50:20.217954686 -0600
-@@ -25,15 +25,6 @@
+--- ./record_reg_vals/record_reg_vals.cu	2024-12-12 14:29:26.000000000 -0700
++++ ./GPU-FPX/analyzer/analyzer.cu	2024-12-17 12:36:27.442109714 -0700
+@@ -1,43 +1,30 @@
+-/*
+- * SPDX-FileCopyrightText: Copyright (c) 2019 NVIDIA CORPORATION & AFFILIATES.
+- * All rights reserved.
+- * SPDX-License-Identifier: BSD-3-Clause
++/* Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+- * modification, are permitted provided that the following conditions are met:
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *  * Neither the name of NVIDIA CORPORATION nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
+  *
+- * 1. Redistributions of source code must retain the above copyright notice, this
+- * list of conditions and the following disclaimer.
+- *
+- * 2. Redistributions in binary form must reproduce the above copyright notice,
+- * this list of conditions and the following disclaimer in the documentation
+- * and/or other materials provided with the distribution.
+- *
+- * 3. Neither the name of the copyright holder nor the names of its
+- * contributors may be used to endorse or promote products derived from
+- * this software without specific prior written permission.
+- *
+- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
++ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
++ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
++ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
++ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
++ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   */
  
@@ -16,7 +65,7 @@
  /* every tool needs to include this once */
  #include "nvbit_tool.h"
  
-@@ -44,10 +35,16 @@
+@@ -48,10 +35,16 @@
  #include "utils/channel.hpp"
  
  /* contains definition of the reg_info_t structure */
@@ -35,7 +84,7 @@
  static __managed__ ChannelDev channel_dev;
  static ChannelHost channel_host;
  
-@@ -63,11 +60,24 @@
+@@ -67,11 +60,24 @@
  /* global control variables for this tool */
  uint32_t instr_begin_interval = 0;
  uint32_t instr_end_interval = UINT32_MAX;
@@ -63,7 +112,7 @@
  
  void nvbit_at_init() {
      setenv("CUDA_MANAGED_FORCE_DEVICE_ALLOC", "1", 1);
-@@ -78,12 +88,19 @@
+@@ -82,12 +88,19 @@
          instr_end_interval, "INSTR_END", UINT32_MAX,
          "End of the instruction interval where to apply instrumentation");
      GET_VAR_INT(verbose, "TOOL_VERBOSE", 0, "Enable verbosity inside the tool");
@@ -83,7 +132,7 @@
  void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
      /* Get related functions of the kernel (device function that can be
       * called by the kernel) */
-@@ -100,6 +117,18 @@
+@@ -104,6 +117,18 @@
          if (!already_instrumented.insert(f).second) {
              continue;
          }
@@ -102,7 +151,7 @@
          const std::vector<Instr *> &instrs = nvbit_get_instrs(ctx, f);
          if (verbose) {
              printf("Inspecting function %s at address 0x%lx\n",
-@@ -113,57 +142,298 @@
+@@ -117,57 +142,298 @@
                  cnt++;
                  continue;
              }
@@ -438,38 +487,70 @@
  
      /* flush channel */
      channel_dev.flush();
-@@ -174,31 +444,67 @@
+@@ -177,62 +443,68 @@
+                          const char *name, void *params, CUresult *pStatus) {
      if (skip_flag) return;
  
-     if (cbid == API_CUDA_cuLaunchKernel_ptsz ||
--        cbid == API_CUDA_cuLaunchKernel) {
-+        cbid == API_CUDA_cuLaunchKernel ||
+-    /* Identify all the possible CUDA launch events */
+-    if (cbid == API_CUDA_cuLaunch || cbid == API_CUDA_cuLaunchKernel_ptsz ||
+-        cbid == API_CUDA_cuLaunchGrid || cbid == API_CUDA_cuLaunchGridAsync ||
++    if (cbid == API_CUDA_cuLaunchKernel_ptsz ||
+         cbid == API_CUDA_cuLaunchKernel ||
+-        cbid == API_CUDA_cuLaunchKernelEx ||
+-        cbid == API_CUDA_cuLaunchKernelEx_ptsz) {
+-        /* cast params to launch parameter based on cbid since if we are here
+-         * we know these are the right parameters types */
+-        CUfunction func;
+-        if (cbid == API_CUDA_cuLaunchKernelEx_ptsz ||
+-            cbid == API_CUDA_cuLaunchKernelEx) {
+-            cuLaunchKernelEx_params* p = (cuLaunchKernelEx_params*)params;
+-            func = p->f;
+-        } else {
+-            cuLaunchKernel_params* p = (cuLaunchKernel_params*)params;
+-            func = p->f;
+-        }
 +        cbid == API_CUDA_cuLaunchCooperativeKernel ||
 +        cbid == API_CUDA_cuLaunchCooperativeKernel_ptsz ||
 +        cbid == API_CUDA_cuLaunchCooperativeKernelMultiDevice) {
-         cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
- 
++        cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
 +
+ 
          if (!is_exit) {
 -            int nregs;
 -            CUDA_SAFECALL(
--                cuFuncGetAttribute(&nregs, CU_FUNC_ATTRIBUTE_NUM_REGS, p->f));
+-                cuFuncGetAttribute(&nregs, CU_FUNC_ATTRIBUTE_NUM_REGS, func));
 -
 -            int shmem_static_nbytes;
 -            CUDA_SAFECALL(
 -                cuFuncGetAttribute(&shmem_static_nbytes,
--                                   CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, p->f));
+-                                   CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
+-                                   func));
 -
--            instrument_function_if_needed(ctx, p->f);
+-            instrument_function_if_needed(ctx, func);
 -
--            nvbit_enable_instrumented(ctx, p->f, true);
+-            nvbit_enable_instrumented(ctx, func, true);
 -
--            printf(
--                "Kernel %s - grid size %d,%d,%d - block size %d,%d,%d - nregs "
--                "%d - shmem %d - cuda stream id %ld\n",
--                nvbit_get_func_name(ctx, p->f), p->gridDimX, p->gridDimY,
--                p->gridDimZ, p->blockDimX, p->blockDimY, p->blockDimZ, nregs,
--                shmem_static_nbytes + p->sharedMemBytes, (uint64_t)p->hStream);
+-            if (cbid == API_CUDA_cuLaunchKernelEx_ptsz ||
+-                cbid == API_CUDA_cuLaunchKernelEx) {
+-                cuLaunchKernelEx_params* p = (cuLaunchKernelEx_params*)params;
+-                printf(
+-                    "Kernel %s - grid size %d,%d,%d - block size %d,%d,%d - nregs "
+-                    "%d - shmem %d - cuda stream id %ld\n",
+-                    nvbit_get_func_name(ctx, func),
+-                    p->config->gridDimX, p->config->gridDimY,
+-                    p->config->gridDimZ, p->config->blockDimX,
+-                    p->config->blockDimY, p->config->blockDimZ, nregs,
+-                    shmem_static_nbytes + p->config->sharedMemBytes,
+-                    (uint64_t)p->config->hStream);
+-            } else {
+-                cuLaunchKernel_params* p = (cuLaunchKernel_params*)params;
+-                printf(
+-                    "Kernel %s - grid size %d,%d,%d - block size %d,%d,%d - nregs "
+-                    "%d - shmem %d - cuda stream id %ld\n",
+-                    nvbit_get_func_name(ctx, func), p->gridDimX, p->gridDimY,
+-                    p->gridDimZ, p->blockDimX, p->blockDimY, p->blockDimZ, nregs,
+-                    shmem_static_nbytes + p->sharedMemBytes, (uint64_t)p->hStream);
+-            }
 +          /*----- Instrumentation Logic --------- */
 +            std::string kernel_name = nvbit_get_func_name(ctx, p->f);
 +            std::string short_name = cut_kernel_name(kernel_name);
@@ -527,7 +608,7 @@
          } else {
              /* make sure current kernel is completed */
              cudaDeviceSynchronize();
-@@ -224,48 +530,55 @@
+@@ -258,48 +530,55 @@
              /* wait here until the receiving thread has not finished with the
               * current kernel */
              while (recv_thread_receiving) {
@@ -604,10 +685,10 @@
          }
      }
      free(recv_buffer);
-@@ -273,7 +586,19 @@
+@@ -307,7 +586,19 @@
  }
  
- void nvbit_at_ctx_init(CUcontext ctx) {
+ void nvbit_tool_init(CUcontext ctx) {
 -    recv_thread_started = true;
 +    printf("#GPU-FPX: Initializing GPU context...\n");
 +    read_from_file(enable_kernels_file,enable_kernels);
@@ -625,7 +706,7 @@
      channel_host.init(0, CHANNEL_SIZE, &channel_dev, NULL);
      pthread_create(&recv_thread, NULL, recv_thread_fun, NULL);
  }
-@@ -283,4 +608,6 @@
+@@ -317,4 +608,6 @@
          recv_thread_started = false;
          pthread_join(recv_thread, NULL);
      }

--- a/GPU-FPX/analyzer/inject_funcs.patch
+++ b/GPU-FPX/analyzer/inject_funcs.patch
@@ -1,6 +1,55 @@
---- ./record_reg_vals/inject_funcs.cu	2022-02-03 09:33:25.000000000 -0700
-+++ ./GPU-FPX/analyzer/inject_funcs.cu	2023-06-05 16:50:20.217954686 -0600
-@@ -25,9 +25,14 @@
+--- ./record_reg_vals/inject_funcs.cu	2024-12-12 14:29:26.000000000 -0700
++++ ./GPU-FPX/analyzer/inject_funcs.cu	2024-12-17 12:35:08.969056227 -0700
+@@ -1,37 +1,38 @@
+-/*
+- * SPDX-FileCopyrightText: Copyright (c) 2019 NVIDIA CORPORATION & AFFILIATES.
+- * All rights reserved.
+- * SPDX-License-Identifier: BSD-3-Clause
++/* Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+- * modification, are permitted provided that the following conditions are met:
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *  * Neither the name of NVIDIA CORPORATION nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
+  *
+- * 1. Redistributions of source code must retain the above copyright notice, this
+- * list of conditions and the following disclaimer.
+- *
+- * 2. Redistributions in binary form must reproduce the above copyright notice,
+- * this list of conditions and the following disclaimer in the documentation
+- * and/or other materials provided with the distribution.
+- *
+- * 3. Neither the name of the copyright holder nor the names of its
+- * contributors may be used to endorse or promote products derived from
+- * this software without specific prior written permission.
+- *
+- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
++ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
++ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
++ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
++ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
++ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   */
  
@@ -15,7 +64,7 @@
  
  #include "utils/utils.h"
  
-@@ -35,47 +40,205 @@
+@@ -39,47 +40,205 @@
  #include "utils/channel.hpp"
  
  /* contains definition of the mem_access_t structure */
@@ -96,7 +145,10 @@
 +    }
 +    return 0; 
 +}
-+
+ 
+-extern "C" __device__ __noinline__ void record_reg_val(int pred, int opcode_id,
+-                                                       uint64_t pchannel_dev,
+-                                                       int32_t num_regs...) {
 +__device__
 +static 
 +__forceinline__ 
@@ -112,10 +164,7 @@
 +    return 0; 
 +}
 +
- 
--extern "C" __device__ __noinline__ void record_reg_val(int pred, int opcode_id,
--                                                       uint64_t pchannel_dev,
--                                                       int32_t num_regs...) {
++
 +extern "C" __device__ __noinline__ void fp32_except(int32_t num_regs, int after_before, int pred, int opcode_id,int kernel_id,int loc_id,
 +                                                            uint64_t pchannel_dev,uint32_t with_lit_except...){
      if (!pred) {

--- a/GPU-FPX/detector/Makefile.patch
+++ b/GPU-FPX/detector/Makefile.patch
@@ -1,7 +1,34 @@
---- ./record_reg_vals/Makefile	2022-02-03 09:33:25.000000000 -0700
-+++ ./GPU-FPX/detector/Makefile	2023-06-05 16:50:20.217954686 -0600
-@@ -1,4 +1,14 @@
--NVCC=nvcc -ccbin=$(CXX) -D_FORCE_INLINES
+--- ./record_reg_vals/Makefile	2024-12-12 14:29:26.000000000 -0700
++++ ./GPU-FPX/detector/Makefile	2024-12-17 12:35:08.969056227 -0700
+@@ -1,34 +1,14 @@
+-# SPDX-FileCopyrightText: Copyright (c) 2017 NVIDIA CORPORATION & AFFILIATES.
+-# All rights reserved.
+-# SPDX-License-Identifier: BSD-3-Clause
+-#
+-# Redistribution and use in source and binary forms, with or without
+-# modification, are permitted provided that the following conditions are met:
+-#
+-# 1. Redistributions of source code must retain the above copyright notice, this
+-# list of conditions and the following disclaimer.
+-#
+-# 2. Redistributions in binary form must reproduce the above copyright notice,
+-# this list of conditions and the following disclaimer in the documentation
+-# and/or other materials provided with the distribution.
+-#
+-# 3. Neither the name of the copyright holder nor the names of its
+-# contributors may be used to endorse or promote products derived from
+-# this software without specific prior written permission.
+-#
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 +mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 +current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 +
@@ -12,14 +39,26 @@
 +SUBDIRS   = $(filter-out ./,$(dir $(SUBMAKEFILES)))
 +.PHONY : $(SUBDIRS)
 +
-+
+ 
+-NVCC=nvcc -ccbin=$(CXX) -D_FORCE_INLINES
+-PTXAS=ptxas
  
  NVCC_VER_REQ=10.1
  NVCC_VER=$(shell $(NVCC) --version | grep release | cut -f2 -d, | cut -f3 -d' ')
-@@ -8,8 +18,9 @@
+@@ -38,18 +18,9 @@
  $(error ERROR: nvcc version >= $(NVCC_VER_REQ) required to compile an nvbit tool! Instrumented applications can still use lower versions of nvcc.)
  endif
  
+-PTXAS_VER_ADD_FLAG=12.3
+-PTXAS_VER=$(shell $(PTXAS) --version | grep release | cut -f2 -d, | cut -f3 -d' ')
+-PTXAS_VER_CHECK=$(shell echo "${PTXAS_VER} >= $(PTXAS_VER_ADD_FLAG)" | bc)
+-
+-ifeq ($(PTXAS_VER_CHECK), 0)
+-MAXRREGCOUNT_FLAG=-maxrregcount=24
+-else
+-MAXRREGCOUNT_FLAG=
+-endif
+-
 -NVBIT_PATH=../../core
 -INCLUDES=-I$(NVBIT_PATH)
 +NVBIT_PATH=../../../core
@@ -28,17 +67,17 @@
  
  LIBS=-L$(NVBIT_PATH) -lnvbit
  NVCC_PATH=-L $(subst bin/nvcc,lib64,$(shell which nvcc | tr -s /))
-@@ -17,23 +28,39 @@
+@@ -57,23 +28,39 @@
  SOURCES=$(wildcard *.cu)
  
  OBJECTS=$(SOURCES:.cu=.o)
--ARCH?=35
+-ARCH?=all
+-
+-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+-current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 +#ARCH?=35
 +#ARCH?=70
  
--mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
--current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
--
 -NVBIT_TOOL=$(current_dir).so
 +# mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 +# current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
@@ -48,16 +87,19 @@
  all: $(NVBIT_TOOL)
  
  $(NVBIT_TOOL): $(OBJECTS) $(NVBIT_PATH)/libnvbit.a
- 	$(NVCC) -arch=sm_$(ARCH) -O3 $(OBJECTS) $(LIBS) $(NVCC_PATH) -lcuda -lcudart_static -shared -o $@
+-	$(NVCC) -arch=$(ARCH) -O3 $(OBJECTS) $(LIBS) $(NVCC_PATH) -lcuda -lcudart_static -shared -o $@
++	$(NVCC) -arch=sm_$(ARCH) -O3 $(OBJECTS) $(LIBS) $(NVCC_PATH) -lcuda -lcudart_static -shared -o $@
  
 -%.o: %.cu common.h
+-	$(NVCC) -dc -c -std=c++11 $(INCLUDES) -Xptxas -cloning=no -Xcompiler -Wall -arch=$(ARCH) -O3 -Xcompiler -fPIC $< -o $@
 +%.o: %.cu 
- 	$(NVCC) -dc -c -std=c++11 $(INCLUDES) -Xptxas -cloning=no -Xcompiler -Wall -arch=sm_$(ARCH) -O3 -Xcompiler -fPIC $< -o $@
++	$(NVCC) -dc -c -std=c++11 $(INCLUDES) -Xptxas -cloning=no -Xcompiler -Wall -arch=sm_$(ARCH) -O3 -Xcompiler -fPIC $< -o $@
  
 -inject_funcs.o: inject_funcs.cu common.h
+-	$(NVCC) $(INCLUDES) $(MAXRREGCOUNT_FLAG) -Xptxas -astoolspatch --keep-device-functions -arch=$(ARCH) -Xcompiler -Wall -Xcompiler -fPIC -c $< -o $@
 +inject_funcs.o: inject_funcs.cu
- 	$(NVCC) $(INCLUDES) -maxrregcount=24 -Xptxas -astoolspatch --keep-device-functions -arch=sm_$(ARCH) -Xcompiler -Wall -Xcompiler -fPIC -c $< -o $@
- 
++	$(NVCC) $(INCLUDES) -maxrregcount=24 -Xptxas -astoolspatch --keep-device-functions -arch=sm_$(ARCH) -Xcompiler -Wall -Xcompiler -fPIC -c $< -o $@
++
 +test: SUBDIRS_TEST
 +
 +SUBDIRS_TEST: $(SUBDIRS)
@@ -67,7 +109,7 @@
 +	for dir in $(SUBDIRS); do \
 +		(cd $$dir && make && python3 ../../../verify_except.py ./main && cd -;) \
 +	done
-+
+ 
  clean:
  	rm -f *.so *.o
 +

--- a/GPU-FPX/detector/detector.patch
+++ b/GPU-FPX/detector/detector.patch
@@ -1,6 +1,55 @@
---- ./record_reg_vals/record_reg_vals.cu	2022-02-03 09:33:25.000000000 -0700
-+++ ./GPU-FPX/detector/detector.cu	2023-06-05 16:50:20.217954686 -0600
-@@ -25,15 +25,6 @@
+--- ./record_reg_vals/record_reg_vals.cu	2024-12-12 14:29:26.000000000 -0700
++++ ./GPU-FPX/detector/detector.cu	2024-12-17 12:36:53.484091227 -0700
+@@ -1,43 +1,30 @@
+-/*
+- * SPDX-FileCopyrightText: Copyright (c) 2019 NVIDIA CORPORATION & AFFILIATES.
+- * All rights reserved.
+- * SPDX-License-Identifier: BSD-3-Clause
++/* Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+- * modification, are permitted provided that the following conditions are met:
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *  * Neither the name of NVIDIA CORPORATION nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
+  *
+- * 1. Redistributions of source code must retain the above copyright notice, this
+- * list of conditions and the following disclaimer.
+- *
+- * 2. Redistributions in binary form must reproduce the above copyright notice,
+- * this list of conditions and the following disclaimer in the documentation
+- * and/or other materials provided with the distribution.
+- *
+- * 3. Neither the name of the copyright holder nor the names of its
+- * contributors may be used to endorse or promote products derived from
+- * this software without specific prior written permission.
+- *
+- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
++ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
++ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
++ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
++ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
++ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   */
  
@@ -16,7 +65,7 @@
  /* every tool needs to include this once */
  #include "nvbit_tool.h"
  
-@@ -44,10 +35,14 @@
+@@ -48,10 +35,14 @@
  #include "utils/channel.hpp"
  
  /* contains definition of the reg_info_t structure */
@@ -33,7 +82,7 @@
  static __managed__ ChannelDev channel_dev;
  static ChannelHost channel_host;
  
-@@ -63,11 +58,21 @@
+@@ -67,11 +58,21 @@
  /* global control variables for this tool */
  uint32_t instr_begin_interval = 0;
  uint32_t instr_end_interval = UINT32_MAX;
@@ -58,7 +107,7 @@
  
  void nvbit_at_init() {
      setenv("CUDA_MANAGED_FORCE_DEVICE_ALLOC", "1", 1);
-@@ -78,12 +83,17 @@
+@@ -82,12 +83,17 @@
          instr_end_interval, "INSTR_END", UINT32_MAX,
          "End of the instruction interval where to apply instrumentation");
      GET_VAR_INT(verbose, "TOOL_VERBOSE", 0, "Enable verbosity inside the tool");
@@ -76,7 +125,7 @@
  void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
      /* Get related functions of the kernel (device function that can be
       * called by the kernel) */
-@@ -100,6 +110,18 @@
+@@ -104,6 +110,18 @@
          if (!already_instrumented.insert(f).second) {
              continue;
          }
@@ -95,7 +144,7 @@
          const std::vector<Instr *> &instrs = nvbit_get_instrs(ctx, f);
          if (verbose) {
              printf("Inspecting function %s at address 0x%lx\n",
-@@ -109,51 +131,160 @@
+@@ -113,51 +131,160 @@
          uint32_t cnt = 0;
          /* iterate on all the static instructions in the function */
          for (auto instr : instrs) {
@@ -126,7 +175,7 @@
 +            else if (is_FP32_instruction(instr->getSass())){
 +              fp32_inst = true;
 +              //printf("SASS of FP32 is %s\n", instr->getSass());
-             }
++            }
 +            else if (is_FP64_instruction(instr->getSass()))
 +              fp32_inst = false;
 +            else
@@ -171,15 +220,14 @@
 +            if(loc_id > 131071) {
 +              std::cout << "too many FP locations which gpufpx cannot handle." << std::endl;
 +              exit(-1);
-+            }
+             }
 +            // if(verbose){
 +            //   std::cout << "The location is: " << locTupleToLoc(id_to_loc_map[loc_id]) << std::endl;
 +            // }
 +  
 +            std::vector<int> reg_num_list;
 +            //printf("op_offset is %d\n",op_offset);
- 
--            if (sass_to_id_map.find(instr->getSass()) ==
++
 +            const InstrType::operand_t *op = instr->getOperand(0);
 +    
 +            if(op->type != InstrType::OperandType::REG)
@@ -200,7 +248,8 @@
 +            }
 +            
 +            assert(reg_num_list.size()==2);
-+
+ 
+-            if (sass_to_id_map.find(instr->getSass()) ==
 +            int opcode_id = 0;
 +            if(print_ill_instr){
 +              if (sass_to_id_map.find(instr->getSass()) ==
@@ -281,38 +330,70 @@
          }
      }
  }
-@@ -174,31 +305,67 @@
+@@ -177,62 +304,68 @@
+                          const char *name, void *params, CUresult *pStatus) {
      if (skip_flag) return;
  
-     if (cbid == API_CUDA_cuLaunchKernel_ptsz ||
--        cbid == API_CUDA_cuLaunchKernel) {
-+        cbid == API_CUDA_cuLaunchKernel ||
+-    /* Identify all the possible CUDA launch events */
+-    if (cbid == API_CUDA_cuLaunch || cbid == API_CUDA_cuLaunchKernel_ptsz ||
+-        cbid == API_CUDA_cuLaunchGrid || cbid == API_CUDA_cuLaunchGridAsync ||
++    if (cbid == API_CUDA_cuLaunchKernel_ptsz ||
+         cbid == API_CUDA_cuLaunchKernel ||
+-        cbid == API_CUDA_cuLaunchKernelEx ||
+-        cbid == API_CUDA_cuLaunchKernelEx_ptsz) {
+-        /* cast params to launch parameter based on cbid since if we are here
+-         * we know these are the right parameters types */
+-        CUfunction func;
+-        if (cbid == API_CUDA_cuLaunchKernelEx_ptsz ||
+-            cbid == API_CUDA_cuLaunchKernelEx) {
+-            cuLaunchKernelEx_params* p = (cuLaunchKernelEx_params*)params;
+-            func = p->f;
+-        } else {
+-            cuLaunchKernel_params* p = (cuLaunchKernel_params*)params;
+-            func = p->f;
+-        }
 +        cbid == API_CUDA_cuLaunchCooperativeKernel ||
 +        cbid == API_CUDA_cuLaunchCooperativeKernel_ptsz ||
 +        cbid == API_CUDA_cuLaunchCooperativeKernelMultiDevice) {
-         cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
- 
++        cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
 +
+ 
          if (!is_exit) {
 -            int nregs;
 -            CUDA_SAFECALL(
--                cuFuncGetAttribute(&nregs, CU_FUNC_ATTRIBUTE_NUM_REGS, p->f));
+-                cuFuncGetAttribute(&nregs, CU_FUNC_ATTRIBUTE_NUM_REGS, func));
 -
 -            int shmem_static_nbytes;
 -            CUDA_SAFECALL(
 -                cuFuncGetAttribute(&shmem_static_nbytes,
--                                   CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, p->f));
+-                                   CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
+-                                   func));
 -
--            instrument_function_if_needed(ctx, p->f);
+-            instrument_function_if_needed(ctx, func);
 -
--            nvbit_enable_instrumented(ctx, p->f, true);
+-            nvbit_enable_instrumented(ctx, func, true);
 -
--            printf(
--                "Kernel %s - grid size %d,%d,%d - block size %d,%d,%d - nregs "
--                "%d - shmem %d - cuda stream id %ld\n",
--                nvbit_get_func_name(ctx, p->f), p->gridDimX, p->gridDimY,
--                p->gridDimZ, p->blockDimX, p->blockDimY, p->blockDimZ, nregs,
--                shmem_static_nbytes + p->sharedMemBytes, (uint64_t)p->hStream);
+-            if (cbid == API_CUDA_cuLaunchKernelEx_ptsz ||
+-                cbid == API_CUDA_cuLaunchKernelEx) {
+-                cuLaunchKernelEx_params* p = (cuLaunchKernelEx_params*)params;
+-                printf(
+-                    "Kernel %s - grid size %d,%d,%d - block size %d,%d,%d - nregs "
+-                    "%d - shmem %d - cuda stream id %ld\n",
+-                    nvbit_get_func_name(ctx, func),
+-                    p->config->gridDimX, p->config->gridDimY,
+-                    p->config->gridDimZ, p->config->blockDimX,
+-                    p->config->blockDimY, p->config->blockDimZ, nregs,
+-                    shmem_static_nbytes + p->config->sharedMemBytes,
+-                    (uint64_t)p->config->hStream);
+-            } else {
+-                cuLaunchKernel_params* p = (cuLaunchKernel_params*)params;
+-                printf(
+-                    "Kernel %s - grid size %d,%d,%d - block size %d,%d,%d - nregs "
+-                    "%d - shmem %d - cuda stream id %ld\n",
+-                    nvbit_get_func_name(ctx, func), p->gridDimX, p->gridDimY,
+-                    p->gridDimZ, p->blockDimX, p->blockDimY, p->blockDimZ, nregs,
+-                    shmem_static_nbytes + p->sharedMemBytes, (uint64_t)p->hStream);
+-            }
 +          /*----- Instrumentation Logic --------- */
 +            std::string kernel_name = nvbit_get_func_name(ctx, p->f);
 +            std::string short_name = cut_kernel_name(kernel_name);
@@ -370,7 +451,7 @@
          } else {
              /* make sure current kernel is completed */
              cudaDeviceSynchronize();
-@@ -224,17 +391,19 @@
+@@ -258,17 +391,19 @@
              /* wait here until the receiving thread has not finished with the
               * current kernel */
              while (recv_thread_receiving) {
@@ -391,7 +472,7 @@
          if (recv_thread_receiving &&
              (num_recv_bytes = channel_host.recv(recv_buffer, CHANNEL_SIZE)) >
                  0) {
-@@ -249,21 +418,26 @@
+@@ -283,21 +418,26 @@
                      recv_thread_receiving = false;
                      break;
                  }
@@ -433,10 +514,10 @@
                  num_processed_bytes += sizeof(reg_info_t);
              }
          }
-@@ -273,6 +447,24 @@
+@@ -307,6 +447,24 @@
  }
  
- void nvbit_at_ctx_init(CUcontext ctx) {
+ void nvbit_tool_init(CUcontext ctx) {
 +    printf("#GPU-FPX: Initializing GPU context...\n");
 +    read_from_file(enable_kernels_file,enable_kernels);
 +    read_from_file(disable_kernels_file, disable_kernels);
@@ -458,7 +539,7 @@
      recv_thread_started = true;
      channel_host.init(0, CHANNEL_SIZE, &channel_dev, NULL);
      pthread_create(&recv_thread, NULL, recv_thread_fun, NULL);
-@@ -283,4 +475,29 @@
+@@ -317,4 +475,29 @@
          recv_thread_started = false;
          pthread_join(recv_thread, NULL);
      }

--- a/GPU-FPX/detector/inject_funcs.patch
+++ b/GPU-FPX/detector/inject_funcs.patch
@@ -1,6 +1,55 @@
---- ./record_reg_vals/inject_funcs.cu	2022-02-03 09:33:25.000000000 -0700
-+++ ./GPU-FPX/detector/inject_funcs.cu	2023-06-05 16:50:20.217954686 -0600
-@@ -25,9 +25,14 @@
+--- ./record_reg_vals/inject_funcs.cu	2024-12-12 14:29:26.000000000 -0700
++++ ./GPU-FPX/detector/inject_funcs.cu	2024-12-17 12:35:08.979056207 -0700
+@@ -1,37 +1,38 @@
+-/*
+- * SPDX-FileCopyrightText: Copyright (c) 2019 NVIDIA CORPORATION & AFFILIATES.
+- * All rights reserved.
+- * SPDX-License-Identifier: BSD-3-Clause
++/* Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+- * modification, are permitted provided that the following conditions are met:
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *  * Neither the name of NVIDIA CORPORATION nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
+  *
+- * 1. Redistributions of source code must retain the above copyright notice, this
+- * list of conditions and the following disclaimer.
+- *
+- * 2. Redistributions in binary form must reproduce the above copyright notice,
+- * this list of conditions and the following disclaimer in the documentation
+- * and/or other materials provided with the distribution.
+- *
+- * 3. Neither the name of the copyright holder nor the names of its
+- * contributors may be used to endorse or promote products derived from
+- * this software without specific prior written permission.
+- *
+- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
++ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
++ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
++ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
++ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
++ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   */
  
@@ -15,7 +64,7 @@
  
  #include "utils/utils.h"
  
-@@ -35,11 +40,181 @@
+@@ -39,11 +40,262 @@
  #include "utils/channel.hpp"
  
  /* contains definition of the mem_access_t structure */
@@ -123,10 +172,7 @@
 +    }
 +    return 0; 
 +}
- 
--extern "C" __device__ __noinline__ void record_reg_val(int pred, int opcode_id,
--                                                       uint64_t pchannel_dev,
--                                                       int32_t num_regs...) {
++
 +__device__
 +static 
 +__forceinline__ 
@@ -198,16 +244,23 @@
 +                                                    uint32_t high_add
 +                                                    ) {
 +    
-     if (!pred) {
-         return;
-     }
-@@ -55,27 +230,284 @@
-     ri.cta_id_y = cta.y;
-     ri.cta_id_z = cta.z;
-     ri.warp_id = get_warpid();
++    if (!pred) {
++        return;
++    }
++
++    int active_mask = __ballot_sync(__activemask(), 1);
++    const int laneid = get_laneid();
++    const int first_laneid = __ffs(active_mask) - 1;
++
++    reg_info_t ri;
++
++    int4 cta = get_ctaid();
++    ri.cta_id_x = cta.x;
++    ri.cta_id_y = cta.y;
++    ri.cta_id_z = cta.z;
++    ri.warp_id = get_warpid();
 +    //ri.location = (char*)location;
-     ri.opcode_id = opcode_id;
--    ri.num_regs = num_regs;
++    ri.opcode_id = opcode_id;
 +    ri.kernel_id = kernel_id;
 +    //ri.loc_id = loc_id;
 +    //ri.inst_type = inst_type;
@@ -235,17 +288,7 @@
 +            ri.mem_index_ar[tid] = __shfl_sync(active_mask, mem_index, tid);
 +            //printf("exce[i] is %d\n",ri.exce_type[tid]);
 +    }
- 
--    if (num_regs) {
--        va_list vl;
--        va_start(vl, num_regs);
--
--        for (int i = 0; i < num_regs; i++) {
--            uint32_t val = va_arg(vl, uint32_t);
--
--            /* collect register values from other threads */
--            for (int tid = 0; tid < 32; tid++) {
--                ri.reg_vals[tid][i] = __shfl_sync(active_mask, val, tid);
++
 +    /* first active lane pushes information on the channel */
 +    if (first_laneid == laneid) {
 +        for(int i =0; i< 32; i++){
@@ -264,12 +307,14 @@
 +                // ChannelDev *channel_dev = (ChannelDev *)pchannel_dev;
 +                // channel_dev->push(&ri, sizeof(reg_info_t));
 +                // break;
-             }
-         }
--        va_end(vl);
++            }
++        }
 +    }
 +}
-+
+ 
+-extern "C" __device__ __noinline__ void record_reg_val(int pred, int opcode_id,
+-                                                       uint64_t pchannel_dev,
+-                                                       int32_t num_regs...) {
 +                                
 +extern "C" __device__ __noinline__ void record_reg_val_32_div0(int pred, int opcode_id,int kernel_id,
 +                                                    //uint64_t location,
@@ -283,22 +328,14 @@
 +                                                    uint32_t high_add
 +                                                    ) {
 +    
-+    if (!pred) {
-+        return;
+     if (!pred) {
+         return;
      }
- 
-+    int active_mask = __ballot_sync(__activemask(), 1);
-+    const int laneid = get_laneid();
-+    const int first_laneid = __ffs(active_mask) - 1;
-+
-+    reg_info_t ri;
-+
-+    int4 cta = get_ctaid();
-+    ri.cta_id_x = cta.x;
-+    ri.cta_id_y = cta.y;
-+    ri.cta_id_z = cta.z;
-+    ri.warp_id = get_warpid();
-+    ri.opcode_id = opcode_id;
+@@ -60,26 +312,202 @@
+     ri.cta_id_z = cta.z;
+     ri.warp_id = get_warpid();
+     ri.opcode_id = opcode_id;
+-    ri.num_regs = num_regs;
 +    ri.kernel_id = kernel_id;
 +    //ri.loc_id = loc_id;
 +    //ri.inst_type = inst_type;
@@ -320,12 +357,20 @@
 +    for (int tid = 0; tid < 32; tid++) {
 +            ri.exce_type[tid] = __shfl_sync(active_mask, exce, tid);
 +            ri.mem_index_ar[tid] = __shfl_sync(active_mask, mem_index, tid);
-+
+ 
+-    if (num_regs) {
+-        va_list vl;
+-        va_start(vl, num_regs);
+-
+-        for (int i = 0; i < num_regs; i++) {
+-            uint32_t val = va_arg(vl, uint32_t);
+-
+-            /* collect register values from other threads */
+-            for (int tid = 0; tid < 32; tid++) {
+-                ri.reg_vals[tid][i] = __shfl_sync(active_mask, val, tid);
 +    }
-     /* first active lane pushes information on the channel */
-     if (first_laneid == laneid) {
--        ChannelDev *channel_dev = (ChannelDev *)pchannel_dev;
--        channel_dev->push(&ri, sizeof(reg_info_t));
++    /* first active lane pushes information on the channel */
++    if (first_laneid == laneid) {
 +        //only transfer if there's an excpeionts
 +        // int sum = 0;
 +        //printf("Checking opcode_id = %d\n",opcode_id);
@@ -344,10 +389,11 @@
 +                // ChannelDev *channel_dev = (ChannelDev *)pchannel_dev;
 +                // channel_dev->push(&ri, sizeof(reg_info_t));
 +                // break;
-+            }
-+        }
+             }
+         }
+-        va_end(vl);
      }
- }
++}
 +
 +extern "C" __device__ __noinline__ void record_reg_val_64_stand(int pred, int opcode_id,int kernel_id,
 +                                                    //uint64_t location,
@@ -406,9 +452,11 @@
 +            ri.mem_index_ar[tid] = __shfl_sync(active_mask, mem_index, tid);
 +    }
 +
-+
-+    /* first active lane pushes information on the channel */
-+    if (first_laneid == laneid) {
+ 
+     /* first active lane pushes information on the channel */
+     if (first_laneid == laneid) {
+-        ChannelDev *channel_dev = (ChannelDev *)pchannel_dev;
+-        channel_dev->push(&ri, sizeof(reg_info_t));
 +        for(int i =0; i< 32; i++){
 +            if(ri.exce_type[i]>0){
 +                uint32_t table_index = encode_index(ri.mem_index_ar[i], ri.exce_type[i]);
@@ -497,6 +545,6 @@
 +                // break;
 +            }
 +        }
-+    }
-+}
+     }
+ }
 +

--- a/GPU-FPX/utility/common.patch
+++ b/GPU-FPX/utility/common.patch
@@ -1,7 +1,55 @@
---- ./record_reg_vals/common.h	2022-02-03 09:33:25.000000000 -0700
-+++ ./GPU-FPX/utility/common.h	2023-06-05 16:50:20.225954535 -0600
-@@ -24,7 +24,8 @@
-  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--- ./record_reg_vals/common.h	2024-12-12 14:29:26.000000000 -0700
++++ ./GPU-FPX/utility/common.h	2024-12-17 12:35:09.029056101 -0700
+@@ -1,34 +1,31 @@
+-/*
+- * SPDX-FileCopyrightText: Copyright (c) 2019 NVIDIA CORPORATION & AFFILIATES.
+- * All rights reserved.
+- * SPDX-License-Identifier: BSD-3-Clause
++/* Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+- * modification, are permitted provided that the following conditions are met:
+- *
+- * 1. Redistributions of source code must retain the above copyright notice, this
+- * list of conditions and the following disclaimer.
+- *
+- * 2. Redistributions in binary form must reproduce the above copyright notice,
+- * this list of conditions and the following disclaimer in the documentation
+- * and/or other materials provided with the distribution.
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *  * Neither the name of NVIDIA CORPORATION nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
+  *
+- * 3. Neither the name of the copyright holder nor the names of its
+- * contributors may be used to endorse or promote products derived from
+- * this software without specific prior written permission.
+- *
+- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
++ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
++ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
++ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
++ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
++ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   */
 -
@@ -10,7 +58,7 @@
  #include <stdint.h>
  
  /* information collected in the instrumentation function and passed
-@@ -35,7 +36,67 @@
+@@ -39,7 +36,67 @@
      int32_t cta_id_z;
      int32_t warp_id;
      int32_t opcode_id;

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 all:analyzer detector
 
-nvbit_tar=nvbit-Linux-x86_64-1.5.5.tar.bz2
+nvbit_version = 1.7.2
+
+nvbit_tar=nvbit-Linux-x86_64-$(nvbit_version).tar.bz2
 nvbit_tool=$(shell pwd)/nvbit_release/tools
 GPUFPX_home=$(nvbit_tool)/GPU-FPX
 
@@ -40,8 +42,8 @@ nvbit_release: $(nvbit_tar)
 	tar -xf $<
 
 $(nvbit_tar):
-	wget https://github.com/NVlabs/NVBit/releases/download/1.5.5/$@
+	wget https://github.com/NVlabs/NVBit/releases/download/v$(nvbit_version)/$@
 
 clean:
 	rm -rf nvbit_release/
-	rm nvbit-Linux-x86_64-1.5.5.tar.bz2
+	rm nvbit-Linux-x86_64-$(nvbit_version).tar.bz2


### PR DESCRIPTION
This updates the used version of Nvbit to 1.7.2 which fixes the issue of the tool deadlocking on newer Nvidia drivers.